### PR TITLE
handle partial io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Patrick Marks <patrick@10xgenomics.com>"]
 
 [features]
 default = ['lz4']
+# Switch on the 'full-test' feature (in release mode), to enable 
+# some long-running stress-tests
+full-test = []
 
 [dependencies]
 serde = "*"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Library for handling out-of-memory sorting of large datasets which need to be pr
 Items of an arbitrary type T implementing Serialize and Deserialize are buffered, sorted according to a customizable sort key, then serialized in chunks with serde + lz4 and written to disk, while maintaing an index and an index of the position and key range of each chunk. 
 
 See [Docs](https://10xgenomics.github.io/rust-shardio) for API and examples.
+
+Note: Enable the 'full-test' feature in Release mode to turn on some long-running stress tests.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1169,6 +1169,21 @@ mod shard_tests {
     }
 
     #[test]
+    fn test_write_at() {
+        //let tmp = tempfile::NamedTempFile::new().unwrap();
+        let tmp = tempfile::tempfile().unwrap();
+
+        let N = (1 << 31) - 1000;
+        let mut buf = Vec::with_capacity(N);
+        for i in 0 .. N {
+            buf.push((i % 254) as u8);
+        }
+
+        let written = write_at(&tmp.as_raw_fd(), 0, &buf).unwrap();
+        assert_eq!(N, written);
+    }
+
+    #[test]
     fn test_shard_round_trip() {
         // Test different buffering configurations
         check_round_trip(10, 20, 0, 1 << 8);
@@ -1178,6 +1193,12 @@ mod shard_tests {
         check_round_trip(128, 4, 1024, 1 << 12);
         check_round_trip(50, 2, 256, 1 << 16);
         check_round_trip(10, 20, 40, 1 << 14);
+    }
+
+    #[test]
+    fn test_shard_round_trip_big_chunks() {
+        // Test different buffering configurations
+        check_round_trip(1<<18, 64, 1<<20, 1 << 21);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1207,18 +1207,21 @@ mod shard_tests {
         items
     }
 
+    // Some tests are configured to only run with the "full-test" feature enabled.
+    // They are too slow to run in debug mode, so you should use release mode.
+    #[cfg(feature = "full-test")]
     #[test]
     fn test_read_write_at() {
         let tmp = tempfile::tempfile().unwrap();
 
         let n = (1 << 31) - 1000;
-        let mut buf = Vec::with_capacity(N);
+        let mut buf = Vec::with_capacity(n);
         for i in 0 .. n {
             buf.push((i % 254) as u8);
         }
 
         let written = write_at(&tmp.as_raw_fd(), 0, &buf).unwrap();
-        assert_eq!(N, written);
+        assert_eq!(n, written);
 
         for i in 0 .. n {
             buf[i] = 0;
@@ -1244,6 +1247,7 @@ mod shard_tests {
         check_round_trip(10, 20, 40, 1 << 14);
     }
 
+    #[cfg(feature = "full-test")]
     #[test]
     fn test_shard_round_trip_big_chunks() {
         // Test different buffering configurations
@@ -1261,16 +1265,14 @@ mod shard_tests {
         check_round_trip_sort_key(50, 2, 256, 1 << 16, true);
         check_round_trip_sort_key(10, 20, 40, 1 << 14, true);
 
-        check_round_trip_sort_key(64, 16, 1 << 17, 1 << 16, true);
-        check_round_trip_sort_key(128, 16, 1 << 17, 1 << 16, true);
-        check_round_trip_sort_key(64, 16, 1 << 16, 1 << 16, true);
+        check_round_trip_sort_key(64, 16, 1 << 17, 1 << 16, true);  
         check_round_trip_sort_key(128, 16, 1 << 16, 1 << 16, true);
-        check_round_trip_sort_key(64, 16, 1 << 15, 1 << 16, true);
         check_round_trip_sort_key(128, 16, 1 << 15, 1 << 16, true);
     }
 
     // Only run this test in release mode for perf testing
-    //#[test]
+    #[cfg(feature = "full-test")]
+    #[test]
     fn test_shard_round_trip_big() {
         // Play with these settings to test perf.
         check_round_trip_opt(1024, 64, 1 << 18, 1 << 20, false);


### PR DESCRIPTION
test_read_write_at will fail on linux without the retry logic, although you have to go up to an extremely large buffer. Presumably lustre will give you partial IO much more often.