### PR TITLE
Make sure ShardSenders are dropped before ShardWriter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+test.shardio


### PR DESCRIPTION
### Changes

1. Include an immutable reference to the`ShardWriter` inside `ShardSender`
2. `ShardSender<T>` is now `ShardSender<'a, T, S>`
3. This required adding the trait bound `S: Send`, but that should not be restrictive at all
4. Update the doc example

### Illegal code
API usage of the form:
```
{
    let mut writer: ShardWriter<...> = ShardWriter::new(...);
    let mut sender = writer.get_sender();
    ...
    writer.finish()?;
}
```
will not compile with a clear message
```
error[E0502]: cannot borrow `writer` as mutable because it is also borrowed as immutable
  --> src/lib.rs:45:9
   |
31 |         let mut sender = writer.get_sender();
   |                          ------ immutable borrow occurs here
...
39 |         writer.finish()?;
   |         ^^^^^^^^^^^^^^^ mutable borrow occurs here
40 |     }
   |     - immutable borrow might be used here, when `sender` is dropped and runs the `Drop` code for type `shardio::ShardSender`
```

### Legal code
You can either not call `finish()`:

```
{
    let writer: ShardWriter<...> = ShardWriter::new(...);
    let mut sender = writer.get_sender();
    ...
}
```

or explicitly scope the `sender` and call finish

```
{
    let mut writer: ShardWriter<...> = ShardWriter::new(...);
    {
        let mut sender = writer.get_sender();
        ...
    }
    writer.finish()
}
```