### PR TITLE
embed type metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ failure = "0.1.5"
 crossbeam-channel = "0.3.8"
 failure_derive = "0.1"
 min-max-heap = "1.2.2"
+log = "^0.4"
+rustc_version_runtime = "^0.1"
+semver = "^0.9"
 
 [dev-dependencies]
 tempfile = "^3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,13 @@ failure_derive = "0.1"
 min-max-heap = "1.2.2"
 
 [dev-dependencies]
-tempfile = "3.0"
+tempfile = "^3.1"
 criterion = "0.2.3"
 fxhash = "0.2.1"
 lazy_static = "1.2"
 pretty_assertions = "0.5.1"
-quickcheck = "0.8.5"
-rand = "0.6.5"
+quickcheck = "^0.9"
+rand = "^0.7"
 is_sorted = "0.1"
 
 [[bench]]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -69,7 +69,6 @@ pub struct ThreadProxyWriter<T: Send + Write> {
 }
 
 impl<T: 'static + Send + Write> ThreadProxyWriter<T> {
-
     /// Create a new `ThreadProxyWriter` that will write to `writer` on a newly created thread
     pub fn new(mut writer: T, buffer_size: usize) -> ThreadProxyWriter<T> {
         let (tx, rx) = bounded::<Option<Vec<u8>>>(10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,18 +793,13 @@ where
             );
         } else {
             // if compiler version is the same, type misnaming is an error
-            if t_typ != type_name::<T>() {
+            if t_typ != type_name::<T>() || s_typ != type_name::<S>() {
                 return Err(format_err!(
-                    "expected shardio type {}, got {}",
+                    "Expected type {} with sort order {}, but got type {} with sort order {}",
                     type_name::<T>(),
-                    t_typ
-                ));
-            }
-            if s_typ != type_name::<S>() {
-                return Err(format_err!(
-                    "expected shardio sort {}, got {}",
                     type_name::<S>(),
-                    s_typ
+                    t_typ,
+                    s_typ,
                 ));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,20 +791,22 @@ where
                 version(),
                 ver
             );
-        }
-        if ver == version() && t_typ != type_name::<T>() {
-            return Err(format_err!(
-                "expected shardio type {}, got {}",
-                type_name::<T>(),
-                t_typ
-            ));
-        }
-        if ver == version() && s_typ != type_name::<S>() {
-            return Err(format_err!(
-                "expected shardio sort {}, got {}",
-                type_name::<S>(),
-                s_typ
-            ));
+        } else {
+            // if compiler version is the same, type misnaming is an error
+            if t_typ != type_name::<T>() {
+                return Err(format_err!(
+                    "expected shardio type {}, got {}",
+                    type_name::<T>(),
+                    t_typ
+                ));
+            }
+            if s_typ != type_name::<S>() {
+                return Err(format_err!(
+                    "expected shardio sort {}, got {}",
+                    type_name::<S>(),
+                    s_typ
+                ));
+            }
         }
         Ok(recs)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //!     let mut all_items_sorted = all_items.clone();
 //!     all_items.sort();
 //!     assert_eq!(all_items, all_items_sorted);
+//!     std::fs::remove_file(filename)?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
stuffs type_name data into the shard metadata section.

We probably don't want to do this, as type_name is explicitly not guaranteed to be stable across rustc versions, from its docs:
> This is intended for diagnostic use. The exact contents and format of the string are not specified, other than being a best-effort description of the type. For example, type_name::<Option<String>>() could return the "Option<String>" or "std::option::Option<std::string::String>", but not "foobar". In addition, the output may change between versions of the compiler.
>
> The type name should not be considered a unique identifier of a type; multiple types may share the same type name.
>
> The current implementation uses the same infrastructure as compiler diagnostics and debuginfo, but this is not guaranteed.