### PR TITLE
Fix clippy compilation error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ where
                 // important note: lz4f (not lz4) is the relevant mode in those charts.
                 .build(&mut self.compress_buffer)?;
 
-            encoder.write(&self.serialize_buffer)?;
+            encoder.write_all(&self.serialize_buffer)?;
             let (_, result) = encoder.finish();
             result?;
         }


### PR DESCRIPTION
```
error: written amount is not handled. Use `Write::write_all` instead
    |
559 |             encoder.write(&self.serialize_buffer)?;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::unused_io_amount)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
```