### PR TITLE
fadvise to and get better read throughput.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ min-max-heap = "1.2.2"
 serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = "0.4.0"
 log = "^0.4"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "^3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 //!     // Open finished file & test chunked reads
 //!     let reader = ShardReader::<DataStruct>::open(filename)?;
 //!
-//!     
+//!
 //!     let mut all_items = Vec::new();
 //!
 //!     // Shardio will divide the key space into 5 roughly equally sized chunks.
@@ -859,7 +859,7 @@ fn advise_will_need(file: &File, offset: usize, len: usize) {
     #[cfg(target_os = "linux")]
     unsafe {
         use std::os::unix::io::AsRawFd;
-        libc::posix_fadvise(file.as_raw_fd(), offset, len, libc::POSIX_FADV_WILLNEED);
+        libc::posix_fadvise(file.as_raw_fd(), offset as i64, len as i64, libc::POSIX_FADV_WILLNEED);
     }
 }
 


### PR DESCRIPTION
WRITE_POS_BAM in particular appears to be limited by how fast shardio can read.

There will be a double fadvise most of the time here, is that a big issue? It's a lot simpler that way.  We're generally using ~8MB chunks, so these syscalls will be amortized over a good amount of data.


Also wondering if I should be doing POSIX_FADV_DONTNEED afterwards we're done with each chunk?  From the manpage it sounds like we would want to find the page boundaries within the chunk.