### PR TITLE
Implement unsorted shard reader API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shardio"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>", "Lance Hepler <lance.hepler@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1413,10 +1413,6 @@ where
 
     /// Open a set of shard files
     pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Result<Self, Error> {
-        assert!(
-            !shard_files.is_empty(),
-            "Need at least 1 shard file to open the reader"
-        );
         let shard_files: Vec<_> = shard_files.iter().map(|f| f.as_ref().into()).collect();
 
         Ok(UnsortedShardReader {
@@ -1526,7 +1522,6 @@ where
 #[cfg(test)]
 mod shard_tests {
     use super::*;
-    use core::num::bignum::tests;
     use is_sorted::IsSorted;
     use pretty_assertions::assert_eq;
     use quickcheck::{Arbitrary, Gen, QuickCheck, StdThreadGen};
@@ -2235,5 +2230,12 @@ mod shard_tests {
         }
         tmp.close()?;
         Ok(())
+    }
+
+    #[test]
+    fn test_empty_open_set() {
+        let shard_files = Vec::<PathBuf>::new();
+        let reader = UnsortedShardReader::<u8>::open_set(&shard_files).unwrap();
+        assert_eq!(reader.count(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1370,6 +1370,15 @@ where
     }
 }
 
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// A group of `len_items` items, from shard `shard`, stored at position `offset`, using `len_bytes` bytes on-disk.
+/// Similar to ShardRecord, just that we don't store the key. Used for `UnsortedShardReader`
+struct KeylessShardRecord {
+    offset: usize,
+    len_bytes: usize,
+    len_items: usize,
+}
+
 /// Read from a collection of shardio files without considering the sort order.
 /// Useful if you just want to iterate over all the items irrespective of the
 /// ordering.
@@ -1379,8 +1388,16 @@ where
     S: SortKey<T>,
 {
     shard_files: Vec<PathBuf>,
-    reader: Option<ShardReaderSingle<T, S>>,
+    // Which file among the shard_files are we reading from
+    active_file_num: usize,
+    // The index of the shard file we are reading from
+    active_file_index: Vec<KeylessShardRecord>,
+    // Which KeylessShardRecord among the active_file_index are we reading now
+    active_index_num: usize,
+    // How many items within a compressed block have we read so far
+    active_index_items_read: usize,
     decoder: Option<lz4::Decoder<BufReader<ReadAdapter<File, File>>>>,
+    phantom: PhantomData<(T, S)>,
 }
 
 impl<T, S> UnsortedShardReader<T, S>
@@ -1396,24 +1413,20 @@ where
 
     /// Open a set of shard files
     pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Result<Self, Error> {
-        // let reader = shard_files
-        //     .first()
-        //     .map(|f| ShardReaderSingle::open(f))
-        //     .transpose()?;
-        // let decoder = reader
-        //     .as_ref()
-        //     .map(|r| {
-        //         let rec = &r.index[0];
-        //         let adp_reader = ReadAdapter::new(&r.file, rec.offset, rec.len_bytes);
-        //         let buf_reader = BufReader::new(adp_reader);
-        //         lz4::Decoder::new(buf_reader)
-        //     })
-        //     .transpose()?;
+        assert!(
+            !shard_files.is_empty(),
+            "Need at least 1 shard file to open the reader"
+        );
+        let shard_files: Vec<_> = shard_files.iter().map(|f| f.as_ref().into()).collect();
 
         Ok(UnsortedShardReader {
-            shard_files: shard_files.iter().map(|f| f.as_ref().into()).collect(),
-            reader: None,
+            shard_files,
+            active_file_num: 0,
+            active_file_index: Vec::new(),
+            active_index_num: 0,
+            active_index_items_read: 0,
             decoder: None,
+            phantom: PhantomData,
         })
     }
 }
@@ -1426,13 +1439,94 @@ where
 {
     type Item = Result<T, Error>;
     fn next(&mut self) -> Option<Self::Item> {
-        unimplemented!()
+        loop {
+            if self.active_file_num >= self.shard_files.len() {
+                // We are done going through all the files
+                return None;
+            }
+            if self.decoder.is_none() {
+                // Open the next file
+                self.active_index_num = 0;
+                self.active_index_items_read = 0;
+
+                let reader = match ShardReaderSingle::<T, S>::open(
+                    &self.shard_files[self.active_file_num],
+                ) {
+                    Ok(r) => r,
+                    Err(e) => return Some(Err(e)),
+                };
+                self.active_file_index = reader
+                    .index
+                    .into_iter()
+                    .map(|r| KeylessShardRecord {
+                        offset: r.offset,
+                        len_bytes: r.len_bytes,
+                        len_items: r.len_items,
+                    })
+                    .collect();
+
+                let decoder = match self.active_file_index.first() {
+                    Some(rec) => lz4::Decoder::new(BufReader::new(ReadAdapter::new(
+                        reader.file,
+                        rec.offset,
+                        rec.len_bytes,
+                    ))),
+                    None => {
+                        // There are no chunks in this file
+                        self.active_file_num += 1;
+                        continue;
+                    }
+                };
+                self.decoder = match decoder {
+                    Ok(d) => Some(d),
+                    Err(e) => return Some(Err(e.into())),
+                };
+            }
+            if self.active_index_items_read
+                >= self.active_file_index[self.active_index_num].len_items
+            {
+                // We are done with this chunk
+                self.active_index_num += 1;
+                self.active_index_items_read = 0;
+
+                if self.active_index_num >= self.active_file_index.len() {
+                    // We are done with this file
+                    self.decoder = None;
+                    self.active_file_num += 1;
+                    self.active_index_num = 0;
+                } else {
+                    // Load up the decoder for the next chunk
+                    let decoder = self.decoder.take().unwrap();
+                    let (buf, _) = decoder.finish();
+                    let file = buf.into_inner().file;
+                    let rec = self.active_file_index[self.active_index_num];
+                    let decoder = lz4::Decoder::new(BufReader::new(ReadAdapter::new(
+                        file,
+                        rec.offset,
+                        rec.len_bytes,
+                    )));
+                    self.decoder = match decoder {
+                        Ok(d) => Some(d),
+                        Err(e) => return Some(Err(e.into())),
+                    };
+                }
+                continue;
+            } else {
+                // Read the next item
+                self.active_index_items_read += 1;
+                match deserialize_from(self.decoder.as_mut().unwrap()) {
+                    Ok(item) => return Some(Ok(item)),
+                    Err(e) => return Some(Err(e.into())),
+                }
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod shard_tests {
     use super::*;
+    use core::num::bignum::tests;
     use is_sorted::IsSorted;
     use pretty_assertions::assert_eq;
     use quickcheck::{Arbitrary, Gen, QuickCheck, StdThreadGen};
@@ -1886,10 +1980,10 @@ mod shard_tests {
             }
 
             // Check the unsorted read
-            // let unsorted_reader = UnsortedShardReader::<T1>::open(tmp.path())?;
-            // let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
-            // let all_items = all_items_res?;
-            // set_compare(&true_items, &all_items);
+            let unsorted_reader = UnsortedShardReader::<T1>::open(tmp.path())?;
+            let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
+            let all_items = all_items_res?;
+            set_compare(&true_items, &all_items);
         }
         Ok(())
     }
@@ -1968,10 +2062,10 @@ mod shard_tests {
                 set_compare(&true_items, &all_items_chunks);
 
                 // Check the unsorted read
-                // let unsorted_reader = UnsortedShardReader::<T1, FieldDSort>::open(tmp.path())?;
-                // let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
-                // let all_items = all_items_res?;
-                // set_compare(&true_items, &all_items);
+                let unsorted_reader = UnsortedShardReader::<T1, FieldDSort>::open(tmp.path())?;
+                let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
+                let all_items = all_items_res?;
+                set_compare(&true_items, &all_items);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@
 //! Data is written to sorted chunks. When reading shardio will merge the data on the fly into a single sorted view. You can
 //! also procss disjoint subsets of sorted data.
 //!
+//! Additionally, you can also iterate through the data in the order they are written to disk. The items will not
+//! in general follow the sort order. Such an iterator does not involve the merge sort step and hence does not
+//! have the memory overhead associated with keeping multiple items in memory to perform the merge sort.
+//!
 //! ```rust
 //! use serde::{Deserialize, Serialize};
 //! use shardio::*;
@@ -67,6 +71,12 @@
 //!     let mut all_items_sorted = all_items.clone();
 //!     all_items.sort();
 //!     assert_eq!(all_items, all_items_sorted);
+//!
+//!     // If you want to iterate through the items in unsorted order.
+//!     let unsorted_items: Vec<_> = UnsortedShardReader::<DataStruct>::open(filename)?.collect();
+//!     // You will get the items in the order they are written to disk.
+//!     assert_eq!(unsorted_items.len(), all_items.len());
+//!
 //!     std::fs::remove_file(filename)?;
 //!     Ok(())
 //! }
@@ -1379,9 +1389,11 @@ struct KeylessShardRecord {
     len_items: usize,
 }
 
-/// Read from a collection of shardio files without considering the sort order.
-/// Useful if you just want to iterate over all the items irrespective of the
-/// ordering.
+/// Read from a collection of shardio files in the order in which items are written without
+/// considering the sort order.
+///
+/// Useful if you just want to iterate over all the items irrespective of the ordering.
+///
 #[allow(dead_code)]
 pub struct UnsortedShardReader<T, S = DefaultSort>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1385,26 +1385,22 @@ where
     <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
     S: SortKey<T>,
 {
-    /// Open a single shard files into reader
+    /// Open a single shard file
     pub fn open<P: AsRef<Path>>(shard_file: P) -> Result<Self, Error> {
+        UnsortedShardReader::open_set(&[shard_file])
+    }
+
+    /// Open a set of shard files
+    pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Result<Self, Error> {
         let mut readers = Vec::new();
-        let reader = ShardReaderSingle::open(shard_file)?;
-        readers.push(reader);
+
+        for p in shard_files {
+            let reader = ShardReaderSingle::open(p)?;
+            readers.push(reader);
+        }
 
         Ok(UnsortedShardReader { readers })
     }
-
-    // Open a set of shard files into an aggregated reader
-    // pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Result<ShardReader<T, S>, Error> {
-    //     let mut readers = Vec::new();
-
-    //     for p in shard_files {
-    //         let reader = ShardReaderSingle::open(p)?;
-    //         readers.push(reader);
-    //     }
-
-    //     Ok(ShardReader { readers })
-    // }
 }
 
 impl<T, S> Iterator for UnsortedShardReader<T, S>


### PR DESCRIPTION
- Read items in the order in which they are written to disk
- Keeps only the index of one shard file in memory when reading from a set of files.
- Criterion benchmarks show that the unsorted reader is faster, as expected.
```
round-trip              time:   [135.44 ms 136.03 ms 136.84 ms]
round-trip-unsorted     time:   [97.869 ms 98.333 ms 98.773 ms]
```