### PR TITLE
Replace `failure` with `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shardio"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>", "Lance Hepler <lance.hepler@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"
@@ -19,8 +19,7 @@ full-test = []
 bincode = "1.3"
 byteorder = "1.3.0"
 lz4 = "1"
-failure = "0.1.5"
-failure_derive = "0.1"
+anyhow = "1"
 min-max-heap = "1.2.2"
 serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = ">=0.4, <=0.5"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Library for out-of-memory sorting of large datasets which need to be processed in multiple map / sort / reduce passes. 
 
-You write a stream of items of type `T` implementing `Serialize` and `Deserialize` to a `ShardWriter`. The items are buffered, sorted according to a customizable sort key, then serialized to disk in chunks with serde + lz4, while maintaing an index of the position and key range of each chunk. You use a `ShardReader` to stream through a item in a selected interval of the key space, in sorted order.
+You write a stream of items of type `T` implementing `Serialize` and `Deserialize` to a `ShardWriter`. The items are buffered, sorted according to a customizable sort key, then serialized to disk in chunks with serde + lz4, while maintaining an index of the position and key range of each chunk. You use a `ShardReader` to stream through a item in a selected interval of the key space, in sorted order.
 
 See [Docs](https://10xgenomics.github.io/rust-shardio) for API and examples.
 

--- a/benches/my_bench.rs
+++ b/benches/my_bench.rs
@@ -10,8 +10,8 @@ use std::io::BufWriter;
 use std::io::Write;
 use std::time::Duration;
 
+use anyhow::Error;
 use criterion::Criterion;
-use failure::Error;
 use serde::{Deserialize, Serialize};
 use shardio::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! use serde::{Deserialize, Serialize};
 //! use shardio::*;
 //! use std::fs::File;
-//! use failure::Error;
+//! use anyhow::Error;
 //!
 //! #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, Debug)]
 //! struct DataStruct {
@@ -96,9 +96,9 @@ use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use std::thread;
 use std::{any::type_name, path::PathBuf};
 
+use anyhow::{format_err, Error};
 use bincode::{deserialize_from, serialize_into};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use failure::{format_err, Error};
 use log::warn;
 use lz4;
 use min_max_heap::MinMaxHeap;


### PR DESCRIPTION
`failure` is [deprecated](https://github.com/rust-lang-deprecated/failure#failure---a-new-error-management-story). `anyhow` is a recommended replacement for `failure::Error`.