### PR TITLE
feat: allow lazily chunking unsorted iteration

### DIFF
--- a/benches/my_bench.rs
+++ b/benches/my_bench.rs
@@ -95,7 +95,7 @@ fn main() {
 
         // Open finished file
         let all_items = if unsorted_read {
-            UnsortedShardReader::<T1>::open(tmp.path())?.collect::<Result<_, _>>()?
+            UnsortedShardReader::<T1>::open(tmp.path()).collect::<Result<_, _>>()?
         } else {
             let reader = ShardReader::<T1>::open(tmp.path())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1859,14 +1859,21 @@ mod shard_tests {
             let all_items = all_items_res?;
             assert!(set_compare(&true_items, &all_items));
 
-            // Check that the skip_lazy feature produces the expected results.
-            let mut unsorted_reader_skip = UnsortedShardReader::<T1>::open(tmp.path());
-            let to_skip = (disk_chunk_size * 3) + 1;
-            let skipped = unsorted_reader_skip.skip_lazy(to_skip)?;
-            assert_eq!(to_skip, skipped);
-            let all_items_res_skip: Result<Vec<_>, Error> = unsorted_reader_skip.collect();
-            let all_items_skip = all_items_res_skip?;
-            assert_eq!(&all_items[to_skip..], &all_items_skip);
+            let check_unsorted_skip = |to_skip: usize| -> Result<(), Error> {
+                let mut unsorted_reader_skip = UnsortedShardReader::<T1>::open(tmp.path());
+                let skipped = unsorted_reader_skip.skip_lazy(to_skip)?;
+                assert_eq!(to_skip, skipped);
+                let all_items_res_skip: Result<Vec<_>, Error> = unsorted_reader_skip.collect();
+                let all_items_skip = all_items_res_skip?;
+                assert_eq!(&all_items[to_skip..], &all_items_skip);
+                Ok(())
+            };
+
+            check_unsorted_skip(0)?;
+            check_unsorted_skip(1)?;
+            check_unsorted_skip(disk_chunk_size)?;
+            check_unsorted_skip(n_items)?;
+            check_unsorted_skip((disk_chunk_size * 3) + 1)?;
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!     assert_eq!(all_items, all_items_sorted);
 //!
 //!     // If you want to iterate through the items in unsorted order.
-//!     let unsorted_items: Vec<_> = UnsortedShardReader::<DataStruct>::open(filename)?.collect();
+//!     let unsorted_items: Vec<_> = UnsortedShardReader::<DataStruct>::open(filename).collect();
 //!     // You will get the items in the order they are written to disk.
 //!     assert_eq!(unsorted_items.len(), all_items.len());
 //!
@@ -84,6 +84,7 @@
 
 #![deny(warnings)]
 #![deny(missing_docs)]
+use std::any::type_name;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fs::File;
@@ -94,7 +95,6 @@ use std::os::unix::fs::FileExt;
 use std::path::Path;
 use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use std::thread;
-use std::{any::type_name, path::PathBuf};
 
 use anyhow::{format_err, Error};
 use bincode::{deserialize_from, serialize_into};
@@ -111,6 +111,9 @@ pub mod helper;
 
 pub use crate::range::Range;
 use range::Rorder;
+
+mod unsorted;
+pub use unsorted::*;
 
 /// The size (in bytes) of a ShardIter object (mostly buffers)
 // ? sizeof(T)
@@ -1392,157 +1395,6 @@ where
     }
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
-/// A group of `len_items` items, from shard `shard`, stored at position `offset`, using `len_bytes` bytes on-disk.
-/// Similar to ShardRecord, just that we don't store the key. Used for `UnsortedShardReader`
-struct KeylessShardRecord {
-    offset: usize,
-    len_bytes: usize,
-    len_items: usize,
-}
-
-/// Read from a collection of shardio files in the order in which items are written without
-/// considering the sort order.
-///
-/// Useful if you just want to iterate over all the items irrespective of the ordering.
-///
-#[allow(dead_code)]
-pub struct UnsortedShardReader<T, S = DefaultSort>
-where
-    S: SortKey<T>,
-{
-    shard_files: Vec<PathBuf>,
-    // Which file among the shard_files are we reading from
-    active_file_num: usize,
-    // The index of the shard file we are reading from
-    active_file_index: Vec<KeylessShardRecord>,
-    // Which KeylessShardRecord among the active_file_index are we reading now
-    active_index_num: usize,
-    // How many items within a compressed block have we read so far
-    active_index_items_read: usize,
-    decoder: Option<lz4::Decoder<BufReader<ReadAdapter<File, File>>>>,
-    phantom: PhantomData<(T, S)>,
-}
-
-impl<T, S> UnsortedShardReader<T, S>
-where
-    T: DeserializeOwned,
-    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
-    S: SortKey<T>,
-{
-    /// Open a single shard file
-    pub fn open<P: AsRef<Path>>(shard_file: P) -> Result<Self, Error> {
-        UnsortedShardReader::open_set(&[shard_file])
-    }
-
-    /// Open a set of shard files
-    pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Result<Self, Error> {
-        let shard_files: Vec<_> = shard_files.iter().map(|f| f.as_ref().into()).collect();
-
-        Ok(UnsortedShardReader {
-            shard_files,
-            active_file_num: 0,
-            active_file_index: Vec::new(),
-            active_index_num: 0,
-            active_index_items_read: 0,
-            decoder: None,
-            phantom: PhantomData,
-        })
-    }
-}
-
-impl<T, S> Iterator for UnsortedShardReader<T, S>
-where
-    T: DeserializeOwned,
-    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
-    S: SortKey<T>,
-{
-    type Item = Result<T, Error>;
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if self.active_file_num >= self.shard_files.len() {
-                // We are done going through all the files
-                return None;
-            }
-            if self.decoder.is_none() {
-                // Open the next file
-                self.active_index_num = 0;
-                self.active_index_items_read = 0;
-
-                let reader = match ShardReaderSingle::<T, S>::open(
-                    &self.shard_files[self.active_file_num],
-                ) {
-                    Ok(r) => r,
-                    Err(e) => return Some(Err(e)),
-                };
-                self.active_file_index = reader
-                    .index
-                    .into_iter()
-                    .map(|r| KeylessShardRecord {
-                        offset: r.offset,
-                        len_bytes: r.len_bytes,
-                        len_items: r.len_items,
-                    })
-                    .collect();
-
-                let decoder = match self.active_file_index.first() {
-                    Some(rec) => lz4::Decoder::new(BufReader::new(ReadAdapter::new(
-                        reader.file,
-                        rec.offset,
-                        rec.len_bytes,
-                    ))),
-                    None => {
-                        // There are no chunks in this file
-                        self.active_file_num += 1;
-                        continue;
-                    }
-                };
-                self.decoder = match decoder {
-                    Ok(d) => Some(d),
-                    Err(e) => return Some(Err(e.into())),
-                };
-            }
-            if self.active_index_items_read
-                >= self.active_file_index[self.active_index_num].len_items
-            {
-                // We are done with this chunk
-                self.active_index_num += 1;
-                self.active_index_items_read = 0;
-
-                if self.active_index_num >= self.active_file_index.len() {
-                    // We are done with this file
-                    self.decoder = None;
-                    self.active_file_num += 1;
-                    self.active_index_num = 0;
-                } else {
-                    // Load up the decoder for the next chunk
-                    let decoder = self.decoder.take().unwrap();
-                    let (buf, _) = decoder.finish();
-                    let file = buf.into_inner().file;
-                    let rec = self.active_file_index[self.active_index_num];
-                    let decoder = lz4::Decoder::new(BufReader::new(ReadAdapter::new(
-                        file,
-                        rec.offset,
-                        rec.len_bytes,
-                    )));
-                    self.decoder = match decoder {
-                        Ok(d) => Some(d),
-                        Err(e) => return Some(Err(e.into())),
-                    };
-                }
-                continue;
-            } else {
-                // Read the next item
-                self.active_index_items_read += 1;
-                match deserialize_from(self.decoder.as_mut().unwrap()) {
-                    Ok(item) => return Some(Ok(item)),
-                    Err(e) => return Some(Err(e.into())),
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod shard_tests {
     use super::*;
@@ -1553,6 +1405,7 @@ mod shard_tests {
     use std::fmt::Debug;
     use std::hash::Hash;
     use std::iter::{repeat, FromIterator};
+    use std::path::PathBuf;
 
     #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PartialOrd, Ord, Hash)]
     struct T1 {
@@ -1835,7 +1688,7 @@ mod shard_tests {
         }
 
         let unsorted_items =
-            UnsortedShardReader::<T, S>::open_set(&files)?.collect::<Result<Vec<_>, _>>()?;
+            UnsortedShardReader::<T, S>::open_set(&files).collect::<Result<Vec<_>, _>>()?;
         assert!(set_compare(&out_items, &unsorted_items));
 
         Ok(out_items)
@@ -2000,7 +1853,7 @@ mod shard_tests {
             }
 
             // Check the unsorted read
-            let unsorted_reader = UnsortedShardReader::<T1>::open(tmp.path())?;
+            let unsorted_reader = UnsortedShardReader::<T1>::open(tmp.path());
             let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
             let all_items = all_items_res?;
             assert!(set_compare(&true_items, &all_items));
@@ -2084,7 +1937,7 @@ mod shard_tests {
                 assert!(set_compare(&true_items, &all_items_chunks));
 
                 // Check the unsorted read
-                let unsorted_reader = UnsortedShardReader::<T1, FieldDSort>::open(tmp.path())?;
+                let unsorted_reader = UnsortedShardReader::<T1, FieldDSort>::open(tmp.path());
                 let all_items_res: Result<Vec<_>, Error> = unsorted_reader.collect();
                 let all_items = all_items_res?;
                 assert!(set_compare(&true_items, &all_items));
@@ -2262,7 +2115,7 @@ mod shard_tests {
     #[test]
     fn test_empty_open_set() {
         let shard_files = Vec::<PathBuf>::new();
-        let reader = UnsortedShardReader::<u8>::open_set(&shard_files).unwrap();
+        let reader = UnsortedShardReader::<u8>::open_set(&shard_files);
         assert_eq!(reader.count(), 0);
     }
 }

--- a/src/unsorted.rs
+++ b/src/unsorted.rs
@@ -42,7 +42,7 @@ where
 impl<T, S> UnsortedShardReader<T, S>
 where
     T: DeserializeOwned,
-    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned + Send,
     S: SortKey<T>,
 {
     /// Open a single shard file.
@@ -138,7 +138,7 @@ where
 impl<T, S> Iterator for UnsortedShardReader<T, S>
 where
     T: DeserializeOwned,
-    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned + Send,
     S: SortKey<T>,
 {
     type Item = Result<T, Error>;
@@ -178,7 +178,7 @@ where
     S: SortKey<T>,
 {
     count: usize,
-    file_index_iter: Box<dyn Iterator<Item = KeylessShardRecord>>,
+    file_index_iter: Box<dyn Iterator<Item = KeylessShardRecord> + Send>,
     shard_iter: Option<UnsortedShardIter<T>>,
     phantom: PhantomData<S>,
 }
@@ -186,7 +186,7 @@ where
 impl<T, S> UnsortedShardFileReader<T, S>
 where
     T: DeserializeOwned,
-    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned + Send,
     S: SortKey<T>,
 {
     /// Create a unsorted reader for a single shard file.

--- a/src/unsorted.rs
+++ b/src/unsorted.rs
@@ -1,0 +1,320 @@
+use anyhow::Error;
+use bincode::deserialize_from;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::cmp::min;
+use std::fs::File;
+use std::io::BufReader;
+use std::marker::PhantomData;
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::DefaultSort;
+use crate::ReadAdapter;
+use crate::ShardReaderSingle;
+use crate::SortKey;
+
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// A group of `len_items` items, from shard `shard`, stored at position `offset`, using `len_bytes` bytes on-disk.
+/// Similar to ShardRecord, just that we don't store the key. Used for `UnsortedShardReader`
+struct KeylessShardRecord {
+    offset: usize,
+    len_bytes: usize,
+    len_items: usize,
+}
+
+/// Read from a collection of shardio files in the order in which items are written without
+/// considering the sort order.
+///
+/// Useful if you just want to iterate over the items irrespective of the ordering.
+pub struct UnsortedShardReader<T, S = DefaultSort>
+where
+    S: SortKey<T>,
+{
+    /// Iterator over the shard files in the set, opening readers.
+    shard_reader_iter: Box<dyn Iterator<Item = Result<UnsortedShardFileReader<T, S>, Error>>>,
+
+    /// Iterator over the current shard file.
+    active_shard_reader: Option<UnsortedShardFileReader<T, S>>,
+}
+
+impl<T, S> UnsortedShardReader<T, S>
+where
+    T: DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    S: SortKey<T>,
+{
+    /// Open a single shard file.
+    pub fn open<P: AsRef<Path>>(shard_file: P) -> Self
+    where
+        <S as SortKey<T>>::Key: 'static,
+    {
+        Self::open_set(&[shard_file])
+    }
+
+    /// Open a set of shard files.
+    pub fn open_set<P: AsRef<Path>>(shard_files: &[P]) -> Self
+    where
+        <S as SortKey<T>>::Key: 'static,
+    {
+        let reader_iter = shard_files
+            .iter()
+            .map(|f| f.as_ref().into())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter_map(|path: PathBuf| UnsortedShardFileReader::new(&path).transpose());
+        Self {
+            shard_reader_iter: Box::new(reader_iter),
+            active_shard_reader: None,
+        }
+    }
+
+    /// Skip the first count items that would be returned by iteration.
+    /// This avoids reading anything into memory besides the indexes for each
+    /// file, and the first chunk that wouldn't be skipped.
+    ///
+    /// Returns the number of items skipped. This will only ever be less than
+    /// count if we exhausted all shard files.
+    pub fn skip(&mut self, count: usize) -> Result<usize, Error> {
+        let mut skipped = 0;
+        loop {
+            let Some(mut file_reader) = self.take_active_reader().transpose()? else {
+                // Ran out of files.
+                break;
+            };
+            let SkipResult {
+                skipped: this_file_skipped,
+                exhausted,
+            } = file_reader.skip(count - skipped)?;
+            skipped += this_file_skipped;
+            if !exhausted {
+                self.active_shard_reader = Some(file_reader);
+                // If we didn't exhaust an entire file, we should be done.
+                assert!(skipped == count);
+                break;
+            }
+        }
+        Ok(skipped)
+    }
+
+    fn take_active_reader(&mut self) -> Option<Result<UnsortedShardFileReader<T, S>, Error>> {
+        let reader = if let Some(reader) = self.active_shard_reader.take() {
+            reader
+        } else {
+            // Advance to the next reader.
+            match self.shard_reader_iter.next() {
+                None => {
+                    // Exhausted all files.
+                    return None;
+                }
+                Some(Err(err)) => {
+                    // Index read error.
+                    return Some(Err(err));
+                }
+                Some(Ok(reader)) => reader,
+            }
+        };
+        Some(Ok(reader))
+    }
+}
+
+impl<T, S> Iterator for UnsortedShardReader<T, S>
+where
+    T: DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    S: SortKey<T>,
+{
+    type Item = Result<T, Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut reader = match self.take_active_reader() {
+                Some(Ok(reader)) => reader,
+                Some(Err(err)) => {
+                    return Some(Err(err));
+                }
+                None => {
+                    return None;
+                }
+            };
+            match reader.next() {
+                Ok(Some(item)) => {
+                    // The reader wasn't exhausted, put it back for the next iteration.
+                    self.active_shard_reader = Some(reader);
+                    return Some(Ok(item));
+                }
+                Ok(None) => {
+                    // Reader is exhausted, loop to next file.
+                }
+                Err(err) => {
+                    // File read error, return it.
+                    return Some(Err(err));
+                }
+            }
+        }
+    }
+}
+
+/// Read from a single shardio file in the order in which items are written without
+/// considering the sort order.
+struct UnsortedShardFileReader<T, S = DefaultSort>
+where
+    S: SortKey<T>,
+{
+    file_index_iter: Box<dyn Iterator<Item = KeylessShardRecord>>,
+    shard_iter: Option<UnsortedShardIter<T>>,
+    phantom: PhantomData<S>,
+}
+
+impl<T, S> UnsortedShardFileReader<T, S>
+where
+    T: DeserializeOwned,
+    <S as SortKey<T>>::Key: Clone + Ord + DeserializeOwned,
+    S: SortKey<T>,
+{
+    /// Create a unsorted reader for a single shard file.
+    /// Return Ok(None) if the specified shard file is empty.
+    pub fn new(path: &Path) -> Result<Option<Self>, Error>
+    where
+        <S as SortKey<T>>::Key: 'static,
+    {
+        let reader = ShardReaderSingle::<T, S>::open(path)?;
+        let mut file_index_iter = reader.index.into_iter().map(|r| KeylessShardRecord {
+            offset: r.offset,
+            len_bytes: r.len_bytes,
+            len_items: r.len_items,
+        });
+        let Some(first_index_entry) = file_index_iter.next() else {
+            // File is empty.
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            shard_iter: Some(UnsortedShardIter::new(reader.file, first_index_entry)?),
+            file_index_iter: Box::new(file_index_iter),
+            phantom: Default::default(),
+        }))
+    }
+
+    /// Get the next item out of this file.
+    pub fn next(&mut self) -> Result<Option<T>, Error> {
+        loop {
+            // Get the next item if we still have a shard iterator.
+            let Some(mut shard_iter) = self.shard_iter.take() else {
+                return Ok(None);
+            };
+            if let Some(item) = shard_iter.next()? {
+                self.shard_iter = Some(shard_iter);
+                return Ok(Some(item));
+            }
+
+            // Advance to the next shard, if there is one.
+            let Some(next_index_record) = self.file_index_iter.next() else {
+                return Ok(None);
+            };
+
+            self.shard_iter = Some(shard_iter.reset(next_index_record)?);
+        }
+    }
+
+    /// Skip the next N items in this file.
+    /// Any full shards that can be skipped will not be read.
+    pub fn skip(&mut self, count: usize) -> Result<SkipResult, Error> {
+        let mut skipped = 0;
+        loop {
+            let Some(mut shard_iter) = self.shard_iter.take() else {
+                // Ran out of shards.
+                return Ok(SkipResult {
+                    skipped,
+                    exhausted: true,
+                });
+            };
+            let SkipResult {
+                skipped: this_shard_skipped,
+                exhausted,
+            } = shard_iter.skip(count - skipped)?;
+            skipped += this_shard_skipped;
+            if !exhausted {
+                self.shard_iter = Some(shard_iter);
+                // If we didn't exhaust an entire shard iterator, we should be done.
+                assert!(skipped == count);
+                return Ok(SkipResult {
+                    skipped,
+                    exhausted: false,
+                });
+            }
+        }
+    }
+}
+
+/// A direct iterator over the items in a single shard in a single file.
+struct UnsortedShardIter<T> {
+    decoder: lz4::Decoder<BufReader<ReadAdapter<File, File>>>,
+    items_remaining: usize,
+    phantom_s: PhantomData<T>,
+}
+
+impl<T> UnsortedShardIter<T>
+where
+    T: DeserializeOwned,
+{
+    pub(crate) fn new(file: File, rec: KeylessShardRecord) -> Result<Self, Error> {
+        Ok(Self {
+            decoder: lz4::Decoder::new(BufReader::new(ReadAdapter::new(
+                file,
+                rec.offset,
+                rec.len_bytes,
+            )))?,
+            items_remaining: rec.len_items,
+            phantom_s: PhantomData,
+        })
+    }
+
+    pub(crate) fn reset(self, rec: KeylessShardRecord) -> Result<Self, Error> {
+        let (buf, _) = self.decoder.finish();
+        Self::new(buf.into_inner().file, rec)
+    }
+
+    /// Return the next item in the iterator.
+    ///
+    /// If this method returns an error, the iterator should be discarded.
+    pub(crate) fn next(&mut self) -> Result<Option<T>, Error> {
+        if self.items_remaining == 0 {
+            return Ok(None);
+        }
+        let next_item = deserialize_from(&mut self.decoder)?;
+        self.items_remaining -= 1;
+        Ok(Some(next_item))
+    }
+
+    /// Skip the specified number of items. If the requested number of items to
+    /// skip is equal to or larger than the number of remaining items, this
+    /// operation performs no I/O.
+    ///
+    /// If this method returns an error, the iterator should be discarded.
+    #[allow(unused)]
+    pub(crate) fn skip(&mut self, count: usize) -> Result<SkipResult, Error> {
+        let can_skip = min(count, self.items_remaining);
+        if can_skip == self.items_remaining {
+            self.items_remaining = 0;
+            return Ok(SkipResult {
+                skipped: can_skip,
+                exhausted: true,
+            });
+        }
+        // If we're not skipping the entire rest of the iterator, load and discard
+        // the requested number of items.
+        for i in 0..can_skip {
+            self.next()?.unwrap_or_else(|| panic!(
+                "inconsistent item count; expected to skip {can_skip} but iteration ended at {}th item", i
+            ));
+        }
+        Ok(SkipResult {
+            skipped: can_skip,
+            exhausted: false,
+        })
+    }
+}
+
+struct SkipResult {
+    skipped: usize,
+    exhausted: bool,
+}

--- a/src/unsorted.rs
+++ b/src/unsorted.rs
@@ -32,7 +32,8 @@ where
     S: SortKey<T>,
 {
     /// Iterator over the shard files in the set, opening readers.
-    shard_reader_iter: Box<dyn Iterator<Item = Result<UnsortedShardFileReader<T, S>, Error>>>,
+    shard_reader_iter:
+        Box<dyn Iterator<Item = Result<UnsortedShardFileReader<T, S>, Error>> + Send>,
 
     /// Iterator over the current shard file.
     active_shard_reader: Option<UnsortedShardFileReader<T, S>>,


### PR DESCRIPTION
Refactors unsorted shard iteration into a few more granular types.

Adds a `skip_lazy` method to the top-level type to allow lazily seeking into a collection of shard files. This allows chunking a set of shard files for parallel unordered iteration by multiple readers without having to read anything more than the shard index plus the first partially-read shard.