### PR TITLE
parameterize compression strategy and add zstd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.80.0
+            toolchain: 1.89.0
             default: true
             components: rustfmt, clippy
       - name: Check Rust formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ min-max-heap = "1.2.2"
 serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = ">=0.4, <=0.6"
 log = "^0.4"
+zstd = "0.13.3"
 
 [dev-dependencies]
 tempfile = "^3.1"

--- a/benches/my_bench.rs
+++ b/benches/my_bench.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Error;
 use criterion::Criterion;
 use serde::{Deserialize, Serialize};
-use shardio::{Compressor, ShardReader, ShardWriter, UnsortedShardReader};
+use shardio::{ShardReader, ShardWriter, UnsortedShardReader};
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PartialOrd, Ord)]
 struct T1 {

--- a/benches/my_bench.rs
+++ b/benches/my_bench.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Error;
 use criterion::Criterion;
 use serde::{Deserialize, Serialize};
-use shardio::{ShardReader, ShardWriter, UnsortedShardReader};
+use shardio::{Compressor, ShardReader, ShardWriter, UnsortedShardReader};
 
 #[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Debug, PartialOrd, Ord)]
 struct T1 {
@@ -68,6 +68,7 @@ fn main() {
                 producer_chunk_size,
                 disk_chunk_size,
                 buffer_size,
+                Compressor::Lz4,
             )?;
             let mut true_items = Vec::with_capacity(n_items);
 

--- a/benches/my_bench.rs
+++ b/benches/my_bench.rs
@@ -68,7 +68,6 @@ fn main() {
                 producer_chunk_size,
                 disk_chunk_size,
                 buffer_size,
-                Compressor::Lz4,
             )?;
             let mut true_items = Vec::with_capacity(n_items);
 

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -15,7 +15,7 @@ use zstd::zstd_safe;
 #[derive(Clone, Copy)]
 pub enum Compressor {
     /// lz4 compression at level 2
-    /// this appears to be a good general trad-off of speed and compression ratio.
+    /// this appears to be a good general trade-off of speed and compression ratio.
     /// note see these benchmarks for useful numers:
     /// http://quixdb.github.io/squash-benchmark/#ratio-vs-compression
     /// important note: lz4f (not lz4) is the relevant mode in those charts.

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -27,22 +27,22 @@ pub enum Compressor {
 }
 
 impl Compressor {
-    const LZ4_ID: &'static [u8; 8] = b"lz4     ";
-    const ZSTD_ID: &'static [u8; 8] = b"zstd    ";
+    const LZ4_MAGIC_NUMBER: u32 = 0x184D2204;
+    const ZSTD_MAGIC_NUMBER: u32 = 0xFD2FB528;
 
     /// Return a fixed-width identifier for this compressor, for encoding into a shard file.
-    pub fn to_id(&self) -> u64 {
+    pub fn to_magic_number(&self) -> u32 {
         match self {
-            Self::Lz4 => u64::from_be_bytes(*Self::LZ4_ID),
-            Self::Zstd => u64::from_be_bytes(*Self::ZSTD_ID),
+            Self::Lz4 => Self::LZ4_MAGIC_NUMBER,
+            Self::Zstd => Self::ZSTD_MAGIC_NUMBER,
         }
     }
 
     /// Match a fixed-width identifier to a known compressor.
-    pub fn from_id(id: u64) -> Result<Self> {
-        match &id.to_be_bytes() {
-            Self::LZ4_ID => Ok(Self::Lz4),
-            Self::ZSTD_ID => Ok(Self::Zstd),
+    pub fn from_magic_number(id: u32) -> Result<Self> {
+        match id {
+            Self::LZ4_MAGIC_NUMBER => Ok(Self::Lz4),
+            Self::ZSTD_MAGIC_NUMBER => Ok(Self::Zstd),
             unknown => bail!("unknown compressor: {unknown:?}"),
         }
     }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,0 +1,85 @@
+//! Abstract over different compressors that could be used.
+//!
+//! For the time being, we support lz4 and zstd, but since we want a given
+//! shard file to internally specify which compressor was used, we do not
+//! plan to support extensible compressor support. This could be changed in the
+//! future through the use of a compile-time plugin registry system like the
+//! inventory crate.
+
+use std::io::{Read, Write};
+
+use anyhow::{bail, Result};
+
+/// The compressors supported by shardio.
+pub enum Compressor {
+    /// lz4 compression at level 2
+    /// this appears to be a good general trad-off of speed and compression ratio.
+    /// note see these benchmarks for useful numers:
+    /// http://quixdb.github.io/squash-benchmark/#ratio-vs-compression
+    /// important note: lz4f (not lz4) is the relevant mode in those charts.
+    Lz4,
+}
+
+impl Compressor {
+    const LZ4_ID: &'static [u8; 8] = b"lz4     ";
+
+    /// Return a fixed-width identifier for this compressor, for encoding into a shard file.
+    pub fn to_id(&self) -> u64 {
+        match self {
+            Self::Lz4 => u64::from_be_bytes(*Self::LZ4_ID),
+        }
+    }
+
+    /// Match a fixed-width identifier to a known compressor.
+    pub fn from_id(id: u64) -> Result<Self> {
+        match &id.to_be_bytes() {
+            Self::LZ4_ID => Ok(Self::Lz4),
+            unknown => bail!("unknown compressor: {unknown:?}"),
+        }
+    }
+
+    /// Return the amount of memory in bytes used by an instance of this decompressor.
+    pub fn decompressor_mem_size_bytes(&self) -> usize {
+        match self {
+            // 32KB of lz4-rs internal buffer
+            // + 64KB of lz4-sys default blockSize (x2)
+            // + 128KB lz4-sys default blockLinked
+            // + 4 lz4-sys checksum
+            Self::Lz4 => 32_768 + 65_536 * 2 + 131_072 + 4,
+        }
+    }
+
+    /// Encode a buffer of data using this compression strategy.
+    /// Write it to the provided writer.
+    pub fn encode(&self, data: &[u8], w: impl Write) -> Result<()> {
+        match self {
+            Self::Lz4 => {
+                let mut encoder = lz4::EncoderBuilder::new().level(2).build(w)?;
+                encoder.write_all(data)?;
+                let (_, result) = encoder.finish();
+                result?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Create a decoder for this compressor, wrapping the provided reader.
+    pub fn decoder<R: Read>(&self, r: R) -> Result<Decoder<R>> {
+        match self {
+            Self::Lz4 => Ok(Decoder::Lz4(lz4::Decoder::new(r)?)),
+        }
+    }
+}
+
+/// Wrap up decoding using different compression strategies.
+pub enum Decoder<R: Read> {
+    Lz4(lz4::Decoder<R>),
+}
+
+impl<R: Read> Read for Decoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Lz4(d) => d.read(buf),
+        }
+    }
+}

--- a/src/range.rs
+++ b/src/range.rs
@@ -57,8 +57,8 @@ impl<K: Ord + Clone> Range<K> {
     #[inline]
     /// Test if `point` in contained in the range `self`
     pub fn contains(&self, point: &K) -> bool {
-        let after_start = self.start.as_ref().map_or(true, |s| point >= s);
-        let before_end = self.end.as_ref().map_or(true, |e| point < e);
+        let after_start = self.start.as_ref().is_none_or(|s| point >= s);
+        let before_end = self.end.as_ref().is_none_or(|e| point < e);
         after_start && before_end
     }
 
@@ -90,7 +90,7 @@ impl<K: Ord + Clone> Range<K> {
     pub(crate) fn cmp(&self, point: &K) -> Rorder {
         if self.contains(point) {
             Rorder::Intersects
-        } else if self.start.as_ref().map_or(false, |s| point < s) {
+        } else if self.start.as_ref().is_some_and(|s| point < s) {
             Rorder::Before
         } else {
             Rorder::After


### PR DESCRIPTION
- Parameterize compression strategy as an enum, with no configurable parameters for the moment.
- Add zstd as a dependency and add a variant for it.
- Add round-trip test cases for zstd compression.
