### PR TITLE
Add a full memory estimate for zstd and a doc test.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = ">=0.4, <=0.6"
 log = "^0.4"
 zstd = "0.13.3"
+zstd-sys = { version = "2", features = ["experimental"] }
 
 [dev-dependencies]
 tempfile = "^3.1"


### PR DESCRIPTION
Call into libzstd to get an accurate memory size of a zstd decompressor.