### PR TITLE
build(deps): Remove dependency on `bindgen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 crossbeam-channel = ">=0.4, <=0.6"
 log = "^0.4"
 zstd = "0.13.3"
-zstd-sys = { version = "2", features = ["experimental"] }
+zstd-sys = { version = "2", default-features = false, features = ["experimental"] }
 
 [dev-dependencies]
 tempfile = "^3.1"


### PR DESCRIPTION
Remove `default-features` from dependency `zstd-sys` to remove the dependency on `bindgen`.
